### PR TITLE
Interpolate the provisioned nodes IP addresses into the plan file.

### DIFF
--- a/docs/5-provision-cluster.md
+++ b/docs/5-provision-cluster.md
@@ -18,29 +18,19 @@ All IP addresses used for the following steps can be found from the output of Te
 
 ## Kismatic-cluster.yaml changes
 
-Now update the `kismatic-cluster.yaml` in the root directory of the repo with the following changes:
+If you `less kismatic-cluster.yaml` and scroll to the bottom you should see that Terraform has interpolated the IP addresses for the nodes.
 
-This can be done by executing the following command:
-
-```
-$ nano kismatic-cluster.yaml
-```
-
-Note: There **must** be space between the `:` and the ip address you enter!
-
-Add the IP address of Master1 to `ip`, `load_balanced_fqdn` and `load_balanced_short_name`  see below
+Here is what you would see for the master node where `<master_ip_address>` will be your master's IP address:
 
 ```
 master:
   expected_count: 1
   nodes:
   - host: master1
-    ip:
-  load_balanced_fqdn:
-  load_balanced_short_name:
+    ip: <master_ip_address>
+  load_balanced_fqdn: <master_ip_address>
+  load_balanced_short_name: <master_ip_address>
 ```
-
-Update the remainder of the IP address in the `kismatic-cluster.yaml` under `etcd`, 'ingress' and `worker`.
 
 ## Provision the cluster using Kismatic
 

--- a/kismatic-cluster.yaml.tpl
+++ b/kismatic-cluster.yaml.tpl
@@ -179,7 +179,7 @@ etcd:
   # left blank.
   nodes:
   - host: etcd1
-    ip:
+    ip: ${etcd_ip}
 
 # Master nodes are the ones that run the Kubernetes control plane components.
 master:
@@ -187,28 +187,28 @@ master:
 
   # If you have set up load balancing for master nodes, enter the FQDN name here.
   # Otherwise, use the IP address of a single master node.
-  load_balanced_fqdn:
+  load_balanced_fqdn: ${master_ip}
 
   # If you have set up load balancing for master nodes, enter the short name here.
   # Otherwise, use the IP address of a single master node.
-  load_balanced_short_name:
+  load_balanced_short_name: ${master_ip}
   nodes:
   - host: master1
-    ip:
+    ip: ${master_ip}
 
 # Worker nodes are the ones that will run your workloads on the cluster.
 worker:
   expected_count: 1
   nodes:
   - host: worker1
-    ip:
+    ip: ${worker_ip}
 
 # Ingress nodes will run the ingress controllers.
 ingress:
   expected_count: 1
   nodes:
   - host: ingress1
-    ip:
+    ip: ${ingress_ip}
 
 # Storage nodes will be used to create a distributed storage cluster that can
 # be consumed by your workloads.


### PR DESCRIPTION
- Updated the docs to reflect the changes.
- Converted the kismatic-cluster.yaml to a template and added variables for the IP addresses.
- Used template_file in Terraform and changed the provisioner to use 'content' instead of 'source'.